### PR TITLE
Check for description in indicators prior to parse html

### DIFF
--- a/esios/indicators.py
+++ b/esios/indicators.py
@@ -16,7 +16,8 @@ class Indicators:
         
         indicators = data.get('indicators', [])
         for indicator in indicators:
-            indicator['description'] = self._html_to_text(indicator['description'])
+            if 'description' in indicator:
+                indicator['description'] = self._html_to_text(indicator['description'])
         return pd.DataFrame(indicators)
 
     def select(self, id):


### PR DESCRIPTION
Check for the field "description" inside the indicator dict prior to call _html_to_text in order to parse the HTML into plain text.

Apparently some indicators don't have a description now.

Solves https://github.com/datons/python-esios/issues/5