### PR TITLE
fix(i90): detect separator columns dynamically by header label

### DIFF
--- a/src/esios/processing/i90.py
+++ b/src/esios/processing/i90.py
@@ -33,6 +33,43 @@ def _any_value_greater_than_30(series: np.ndarray) -> bool:
     return any(v > 30 for v in series if isinstance(v, (int, float, np.integer, np.floating)) and not np.isnan(v))
 
 
+# Labels that REE uses for the cells sitting between the index columns and the
+# per-period value columns of an I90 sheet. Match is exact (case-insensitive,
+# trimmed). The count of these cells per sheet has varied across REE format
+# revisions — historically 2 ("Hora" / "Cuarto de Hora del dia" + "Total");
+# from Oct 2025 the MTU 15-min transition dropped "Total" on several sheets,
+# leaving 1. Counting them dynamically keeps the parser resilient to either.
+_SEPARATOR_LABELS = frozenset({
+    "cuarto de hora del dia",
+    "hora del dia",
+    "hora",
+    "total",
+    "indicadores",
+})
+
+
+def _count_header_separators(row: np.ndarray, idx_col_start: int) -> int:
+    """Count separator cells immediately preceding the time-value block.
+
+    Walks ``row`` backwards from ``idx_col_start - 1``, incrementing on each
+    cell whose text matches a known separator label and stopping at the first
+    non-matching cell or NaN. A NaN cell signals the start of the index-column
+    placeholder zone in double-header layouts (where index labels live on the
+    other header row, leaving the date row blank under each index position).
+    """
+    n = 0
+    for i in range(idx_col_start - 1, -1, -1):
+        cell = row[i]
+        if cell is None or (isinstance(cell, float) and np.isnan(cell)):
+            break
+        text = str(cell).strip().lower()
+        if text in _SEPARATOR_LABELS:
+            n += 1
+            continue
+        break
+    return n
+
+
 class I90Book:
     """Represents an I90DIA workbook (XLS) with lazy sheet preprocessing.
 
@@ -221,6 +258,11 @@ class I90Sheet:
             return pd.DataFrame()
 
         columns_date = self._normalize_datetime_columns(columns_prior[idx_col_start:])
+        # _normalize_datetime_columns sets _n_columns_totals from the time-block
+        # content (NaN-filler vs sequential). Override with a header-label count
+        # so the index slice survives REE format revisions that add or drop a
+        # "Total" column without touching the time-axis encoding.
+        self._n_columns_totals = _count_header_separators(columns_prior, idx_col_start)
         columns_variable = columns[idx_col_start:]
         columns_index = columns[: idx_col_start - self._n_columns_totals]
 
@@ -230,6 +272,7 @@ class I90Sheet:
         self, idx_col_start: int, columns: np.ndarray
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray, None]:
         columns_date = self._normalize_datetime_columns(columns[idx_col_start:])
+        self._n_columns_totals = _count_header_separators(columns, idx_col_start)
         columns_index = columns[: idx_col_start - self._n_columns_totals]
         return columns, columns_index, columns_date, None
 

--- a/tests/test_i90.py
+++ b/tests/test_i90.py
@@ -7,7 +7,11 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 
-from esios.processing.i90 import I90Sheet, _any_value_greater_than_30
+from esios.processing.i90 import (
+    I90Sheet,
+    _any_value_greater_than_30,
+    _count_header_separators,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -165,3 +169,151 @@ class TestNormalizeQuarterlyNaNFiller:
         s = _make_sheet()
         s._normalize_datetime_columns(_full_nan_filler_columns())
         assert s._n_columns_totals == 3
+
+
+# ---------------------------------------------------------------------------
+# _count_header_separators — header-label-based separator counting
+#
+# Headers below are calques of real REE I90 layouts. The counter walks back
+# from idx_col_start, counting cells whose text equals a known separator
+# label ('Cuarto de Hora del dia', 'Hora', 'Total', 'Indicadores', 'Hora del
+# dia'), stopping at the first non-matching cell or NaN.
+# ---------------------------------------------------------------------------
+
+
+class TestCountHeaderSeparators:
+    def test_returns_zero_when_no_separators(self):
+        """If the cell right before the time block is a real index column."""
+        row = np.array(["Redespacho", "Tipo", "1.0", "2.0"], dtype=object)
+        assert _count_header_separators(row, idx_col_start=2) == 0
+
+    def test_pre_mtu_rr_price_layout_returns_2(self):
+        """I90DIA11 jun-2025: [Redespacho, Tipo, Cuarto de Hora del dia, Total, 1, …]."""
+        row = np.array(
+            ["Redespacho", "Tipo", "Cuarto de Hora del dia", "Total", "1.0", "2.0"],
+            dtype=object,
+        )
+        assert _count_header_separators(row, idx_col_start=4) == 2
+
+    def test_post_mtu_rr_price_layout_returns_1(self):
+        """I90DIA11 nov-2025: 'Total' dropped → [Redespacho, Cuarto de Hora del dia, 1, …]."""
+        row = np.array(
+            ["Redespacho", "Cuarto de Hora del dia", "1.0", "2.0"],
+            dtype=object,
+        )
+        assert _count_header_separators(row, idx_col_start=2) == 1
+
+    def test_pre_2024_hourly_layout_returns_2(self):
+        """I90DIA08 2014: [Redespacho, Tipo, …, Signo de Energía, Hora, Total, 00-01, …]."""
+        row = np.array(
+            [
+                "Redespacho", "Tipo", "Sentido", "Unidad de Programación",
+                "Tipo Oferta", "Tipo cálculo", "Tipo Restricción",
+                "Signo de Energía", "Hora", "Total", "00-01", "01-02",
+            ],
+            dtype=object,
+        )
+        assert _count_header_separators(row, idx_col_start=10) == 2
+
+    def test_post_mtu_rtr_price_layout_returns_1(self):
+        """I90DIA10 nov-2025: 'Total' dropped + index reordered."""
+        row = np.array(
+            [
+                "Redespacho", "Sentido", "Unidad de Programación", "Tipo Oferta",
+                "Tipo cálculo", "Signo de Energía", "Cuarto de Hora del dia",
+                "1.0", "2.0",
+            ],
+            dtype=object,
+        )
+        assert _count_header_separators(row, idx_col_start=7) == 1
+
+    def test_double_index_date_row_with_nan_index_placeholders(self):
+        """Double-header layout (e.g. I90DIA30 jun-2025): the date row carries
+        the separator labels; positions under each real index column are NaN.
+        The counter must stop at the first NaN (= start of the index zone).
+        """
+        row = np.array(
+            [np.nan, np.nan, np.nan, np.nan,
+             "Cuarto de Hora del dia", "Total", "1.0", "2.0"],
+            dtype=object,
+        )
+        assert _count_header_separators(row, idx_col_start=6) == 2
+
+    def test_double_index_post_mtu_dropped_total(self):
+        """I90DIA30 nov-2025 (single-index path post-MTU)."""
+        row = np.array(
+            ["Redespacho", "Sentido", "Tipo QH",
+             "Cuarto de Hora del dia", "1.0", "2.0"],
+            dtype=object,
+        )
+        assert _count_header_separators(row, idx_col_start=4) == 1
+
+    def test_match_is_case_insensitive(self):
+        row = np.array(["Redespacho", "TOTAL", "1.0"], dtype=object)
+        assert _count_header_separators(row, idx_col_start=2) == 1
+
+    def test_match_is_whitespace_tolerant(self):
+        row = np.array(["Redespacho", "  Total  ", "1.0"], dtype=object)
+        assert _count_header_separators(row, idx_col_start=2) == 1
+
+    def test_indicadores_counts_as_separator(self):
+        """Variable-row layout: [Redespacho, Tipo, Indicadores, Precio Marginal …, …]."""
+        row = np.array(
+            ["Redespacho", "Tipo", "Indicadores", "Precio Marginal", "1.0"],
+            dtype=object,
+        )
+        # idx_col_start = 4 → walk back from i=3
+        # i=3 'Precio Marginal' is not a separator → stop, return 0
+        assert _count_header_separators(row, idx_col_start=4) == 0
+        # But when adjacent to time block it counts:
+        row2 = np.array(["Redespacho", "Tipo", "Indicadores", "1.0"], dtype=object)
+        assert _count_header_separators(row2, idx_col_start=3) == 1
+
+    def test_unknown_label_immediately_after_index_stops_counter(self):
+        """Non-separator labels do not get absorbed even when next to time block."""
+        row = np.array(["Redespacho", "Foo Bar", "1.0"], dtype=object)
+        assert _count_header_separators(row, idx_col_start=2) == 0
+
+    def test_empty_string_breaks_counter(self):
+        row = np.array(["Redespacho", "", "Total", "1.0"], dtype=object)
+        # i=2 'Total' → sep, i=1 '' → break → returns 1
+        assert _count_header_separators(row, idx_col_start=3) == 1
+
+
+# ---------------------------------------------------------------------------
+# _preprocess_*_index — verify the dynamic counter overrides the heuristic
+# from _normalize_datetime_columns when slicing the index portion.
+# ---------------------------------------------------------------------------
+
+
+class TestPreprocessOverrideIntegration:
+    def test_single_index_post_mtu_layout_keeps_redespacho_in_index(self):
+        """I90DIA11 nov-2025 regression: pre-fix this consumed 'Redespacho' as
+        a 'Total' placeholder and returned an empty DataFrame. Post-fix the
+        index slice keeps it.
+        """
+        s = _make_sheet()
+        # Plant a quarterly time block to match real shape (96 periods).
+        time_block = np.array([float(i) for i in range(1, 97)], dtype=object)
+        columns = np.concatenate([
+            np.array(["Redespacho", "Cuarto de Hora del dia"], dtype=object),
+            time_block,
+        ])
+        result = s._preprocess_single_index(idx_col_start=2, columns=columns)
+        _, columns_index, _, _ = result
+        assert list(columns_index) == ["Redespacho"]
+        assert s._n_columns_totals == 1
+
+    def test_single_index_pre_mtu_layout_still_drops_total(self):
+        """I90DIA11 jun-2025 (and 2014-2024): two separators (Cuarto/Hora + Total)."""
+        s = _make_sheet()
+        time_block = np.array([float(i) for i in range(1, 97)], dtype=object)
+        columns = np.concatenate([
+            np.array(["Redespacho", "Tipo", "Cuarto de Hora del dia", "Total"],
+                     dtype=object),
+            time_block,
+        ])
+        result = s._preprocess_single_index(idx_col_start=4, columns=columns)
+        _, columns_index, _, _ = result
+        assert list(columns_index) == ["Redespacho", "Tipo"]
+        assert s._n_columns_totals == 2


### PR DESCRIPTION
REE removed the "Total" column from several I90 sheets (07, 08, 10, 11, 30) as part of the Oct 2025 MTU 15-min transition. The parser hardcoded _n_columns_totals to 2 (or 3 in NaN-filler quarterly format) based on time- block content, then sliced the index portion of the header with that count. Post-MTU files have only 1 separator cell ("Cuarto de Hora del dia"), so the slice consumed a real index column ('Redespacho', 'Tipo Restricción', 'Tipo QH', 'Signo de Energía', depending on the sheet). I90DIA11 returned an empty DataFrame outright; DIA07/08/10/30 returned malformed rows with missing dimensions.

Introduce _count_header_separators that walks the header backwards from the first time column, counting only cells whose text matches a known separator label (Cuarto de Hora del dia, Hora, Hora del dia, Total, Indicadores). Stops at the first NaN (= index-placeholder zone in double- header layouts) or unknown label. Override the NaN-derived heuristic at both _preprocess_*_index call sites; _normalize_datetime_columns keeps the original side effect for backwards compat with existing test surface.

Verified against jun-2025 (pre-MTU, n=2 preserved) and nov-2025 (post-MTU, n=1 detected); also 2014/2018/2020/2024 fixtures continue to parse with n=2. DIA11 recovers from 0 rows to 192 rows in nov-2025; DIA07/08/10/30 regain their full index column set.

Tests: 12 new unit tests on _count_header_separators covering both eras, case/whitespace tolerance, NaN-break behavior, and unknown-label stop; 2 integration tests on _preprocess_single_index verifying the regression fixture. 29/29 i90 tests pass, full suite 106/106 (excluding network).